### PR TITLE
Refactor sponsors grid

### DIFF
--- a/_includes/sponsor-grid.html
+++ b/_includes/sponsor-grid.html
@@ -2,7 +2,7 @@
 <div class="sponsors">
   {% if site.data.sponsors.smart_city_tier %}
     <h3>Smart City</h3>
-    <div class="sponsors--smart-city">
+    <div class="sponsors__smart-city">
       {%- for tier in site.data.sponsors.smart_city_tier -%}
         {% include sponsor.html
                    name=sponsor.name
@@ -15,7 +15,7 @@
   {% endif %}
   {% if site.data.sponsors.city_planner_tier %}
     <h3>City Planner</h3>
-    <div class="sponsors--city-planner">
+    <div class="sponsors__city-planner">
       {%- for tier in site.data.sponsors.city_planner_tier -%}
         {% include sponsor.html
                    name=sponsor.name
@@ -28,7 +28,7 @@
   {% endif %}
   {% if site.data.sponsors.civic_duties_tier %}
     <h3>Civiv Duty</h3>
-    <div class="sponsors--civic-duty">
+    <div class="sponsors__civic-duty">
       {%- for tier in site.data.sponsors.city_planner_tier -%}
         {% include sponsor.html
                    name=sponsor.name
@@ -41,7 +41,7 @@
   {% endif %}
   {% if site.data.sponsors.community_tier %}
     <h3>Community</h3>
-    <div class="sponsors--community">
+    <div class="sponsors__community">
       {%- for sponsor in site.data.sponsors.community_tier -%}
         {% include sponsor.html
                    name=sponsor.name

--- a/_includes/sponsor-grid.html
+++ b/_includes/sponsor-grid.html
@@ -1,83 +1,57 @@
 
 <div class="sponsors">
-  <div class="smart-city--sponsor-grid">
-
-    {%- for tier in site.data.sponsors.smart_city_tier -%}
-    <div class="tier-item">
-      <h5>Smart City</h5>
-      <div class="sponsor-logo">
-        <a href="{{ tier.url }}" target="_blank">
-          <img src="{{ tier.img }}" alt="Sponsor - {{ tier.name }}" />
-        </a>
-      </div>
-      <div class="sponsor-bottom">
-        {%- for social_link in tier.social_links -%}
-          <a href="{{ social_link.url }}" target="_blank"><i class="fa fa-{{social_link.name}}"></i></a>
-        {%- endfor -%}
-      </div>
+  {% if site.data.sponsors.smart_city_tier %}
+    <h3>Smart City</h3>
+    <div class="sponsors--smart-city">
+      {%- for tier in site.data.sponsors.smart_city_tier -%}
+        {% include sponsor.html
+                   name=sponsor.name
+                   url=sponsor.url
+                   img=sponsor.img
+                   social_links=sponsor.social_links
+        %}
+      {%- endfor -%}
     </div>
-    {%- endfor -%}
-  </div>
-
-  <div class="city-planner--sponsor-grid sponsor-grid">
-
-    {%- for tier in site.data.sponsors.city_planner_tier -%}
-    <div class="tier-item">
-      <h5>City Planner</h5>
-      <div class="sponsor-logo">
-        <a href="{{ tier.url }}" target="_blank">
-          <img src="{{ tier.img }}" alt="Sponsor - {{ tier.name }}" />
-        </a>
-      </div>
-      <div class="sponsor-bottom">
-        {%- for social_link in tier.social_links -%}
-          <a href="{{ social_link.url }}" target="_blank"><i class="fa fa-{{social_link.name}}"></i></a>
-        {%- endfor -%}
-      </div>
+  {% endif %}
+  {% if site.data.sponsors.city_planner_tier %}
+    <h3>City Planner</h3>
+    <div class="sponsors--city-planner">
+      {%- for tier in site.data.sponsors.city_planner_tier -%}
+        {% include sponsor.html
+                   name=sponsor.name
+                   url=sponsor.url
+                   img=sponsor.img
+                   social_links=sponsor.social_links
+        %}
+      {%- endfor -%}
     </div>
-    {%- endfor -%}
-  </div>
-
-  <div class="civic-duty--sponsor-grid">
-
-    {%- for tier in site.data.sponsors.city_planner_tier -%}
-
-    <div class="tier-item">
-      <h5>Civiv Duty</h5>
-      <div class="sponsor-logo">
-        <a href="{{ tier.url }}" target="_blank">
-          <img src="{{ tier.img }}" alt="Sponsor - {{ tier.name }}" />
-        </a>
-      </div>
-      <div class="sponsor-bottom">
-        {%- for social_link in tier.social_links -%}
-          <a href="{{ social_link.url }}" target="_blank"><i class="fa fa-{{social_link.name}}"></i></a>
-        {%- endfor -%}
-      </div>
+  {% endif %}
+  {% if site.data.sponsors.civic_duties_tier %}
+    <h3>Civiv Duty</h3>
+    <div class="sponsors--civic-duty">
+      {%- for tier in site.data.sponsors.city_planner_tier -%}
+        {% include sponsor.html
+                   name=sponsor.name
+                   url=sponsor.url
+                   img=sponsor.img
+                   social_links=sponsor.social_links
+        %}
+      {%- endfor -%}
     </div>
-    {%- endfor -%}
-  </div>
-
-  <div class="community--sponsor-grid">
-
-    {%- for tier in site.data.sponsors.community_tier -%}
-
-    <div class="tier-item">
-      <h5>Community</h5>
-      <div class="sponsor-logo">
-        <a href="{{ tier.url }}" target="_blank">
-          <img src="{{ tier.img }}" alt="Sponsor - {{ tier.name }}" />
-        </a>
-      </div>
-      <div class="sponsor-bottom">
-        {%- for social_link in tier.social_links -%}
-          <a href="{{ social_link.url }}" target="_blank"><i class="fa fa-{{social_link.name}}"></i></a>
-        {%- endfor -%}
-      </div>
+  {% endif %}
+  {% if site.data.sponsors.community_tier %}
+    <h3>Community</h3>
+    <div class="sponsors--community">
+      {%- for sponsor in site.data.sponsors.community_tier -%}
+        {% include sponsor.html
+                   name=sponsor.name
+                   url=sponsor.url
+                   img=sponsor.img
+                   social_links=sponsor.social_links
+        %}
+      {%- endfor -%}
     </div>
-    {%- endfor -%}
-  </div>
-
+  {% endif %}
 </div>
 
 <div class="text-center">

--- a/_includes/sponsor.html
+++ b/_includes/sponsor.html
@@ -1,0 +1,12 @@
+<div class="tier-item">
+  <div class="sponsor-logo">
+    <a href="{{ include.url }}" target="_blank">
+      <img src="{{ include.img }}" alt="Sponsor - {{ include.name }}" />
+    </a>
+  </div>
+  <div class="sponsor-bottom">
+    {%- for social_link in include.social_links -%}
+      <a href="{{ social_link.url }}" target="_blank"><i class="fa fa-{{social_link.name}}"></i></a>
+    {%- endfor -%}
+  </div>
+</div>

--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -107,12 +107,6 @@
     max-width: $width;
     border-radius: 6px;
     padding: 0.5rem;
-		transition: 0.3s ease-in-out;
-		box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-	}
-
-	.tier-item:hover {
-		transform: translateY(-10px);
 	}
 
 	img {
@@ -121,34 +115,26 @@
 		border-bottom-right-radius: 6px;
 	}
 
-
-	h5 {
-		background-color: white;
-		display: block;
-		text-align: center;
-		font-weight: 600;
-		margin: 0;
-		border-top-left-radius: 6px;
-		border-top-right-radius: 6px;
-	}
 }
 
-
 .sponsors {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: center;
-
-	.smart-city--sponsor-grid { @include sponsor-grid-tier(320px); }
-	.city-planner--sponsor-grid { @include sponsor-grid-tier(160px); }
-  .civic-duty--sponsor-grid { @include sponsor-grid-tier(140px); }
-  .community--sponsor-grid { @include sponsor-grid-tier(120px); }
-
+	text-align: center;
+	&--smart-city {
+		@include sponsor-grid-tier(320px);
+	}
+	&--city-planner {
+		@include sponsor-grid-tier(160px);
+	}
+  &--civic-duty {
+		@include sponsor-grid-tier(140px);
+	}
+  &--community {
+		@include sponsor-grid-tier(120px);
+	}
   .sponsor-logo {
   	min-height: 110px;
   }
-  
-  div .tier-item div.sponsor-bottom { 
+  .tier-item .sponsor-bottom {
   	vertical-align: bottom;
 		display: flex;
 		justify-content: space-between;
@@ -156,5 +142,4 @@
 		padding-left: 5px;
 		padding-right: 5px;
   }
-
 }

--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -119,16 +119,16 @@
 
 .sponsors {
 	text-align: center;
-	&--smart-city {
+	&__smart-city {
 		@include sponsor-grid-tier(320px);
 	}
-	&--city-planner {
+	&__city-planner {
 		@include sponsor-grid-tier(160px);
 	}
-  &--civic-duty {
+  &__civic-duty {
 		@include sponsor-grid-tier(140px);
 	}
-  &--community {
+  &__community {
 		@include sponsor-grid-tier(120px);
 	}
   .sponsor-logo {


### PR DESCRIPTION
addresses #56 

- puts sponsors in include
- loses the "card" styling
- moves tier label out of sponsor

The sponsor-grid.html could still be DRYer if the tier label was in the data file (basically it could just be one big loop at that point), but maybe the flexibility w/ handling different tiers differently could be useful in the future... 